### PR TITLE
Fixed Namespaces, HexView, Disassembly view, and keypress events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ libpince/libscanmem/*
 *.py[cod]
 *$py.class
 gdb_pince/*
+*.gnbs.conf

--- a/GUI/CustomAbstractTableModels/AsciiModel.py
+++ b/GUI/CustomAbstractTableModels/AsciiModel.py
@@ -26,11 +26,11 @@ class QAsciiModel(QHexModel):
         super().__init__(row_count, column_count, parent)
 
     def data(self, QModelIndex, int_role=None):
-        if (not self.data_array is None and len(self.data_array) > 0):
+        if (not self.data_array is None and len(self.data_array) > 0 and QModelIndex.isValid()):
             if int_role == Qt.ItemDataRole.BackgroundRole:
                 address = self.current_address + QModelIndex.row() * self.column_count + QModelIndex.column()
                 if SysUtils.modulo_address(address, GDB_Engine.inferior_arch) in self.breakpoint_list:
                     return QVariant(QColor.red)
-            else:
+            elif int_role == Qt.ItemDataRole.DisplayRole:
                 return QVariant(SysUtils.aob_to_str(self.data_array[QModelIndex.row() * self.column_count + QModelIndex.column()]))
         return QVariant()

--- a/GUI/CustomAbstractTableModels/AsciiModel.py
+++ b/GUI/CustomAbstractTableModels/AsciiModel.py
@@ -26,15 +26,11 @@ class QAsciiModel(QHexModel):
         super().__init__(row_count, column_count, parent)
 
     def data(self, QModelIndex, int_role=None):
-        if not QModelIndex.isValid():
-            return QVariant()
-        if int_role == Qt.ItemDataRole.BackgroundRole:
-            address = self.current_address + QModelIndex.row() * self.column_count + QModelIndex.column()
-            if SysUtils.modulo_address(address, GDB_Engine.inferior_arch) in self.breakpoint_list:
-                return QVariant(QColor(Qt.red))
-        elif int_role != Qt.DisplayRole:
-            return QVariant()
-        if self.data_array is None:
-            return QVariant()
-        return QVariant(
-            SysUtils.aob_to_str(self.data_array[QModelIndex.row() * self.column_count + QModelIndex.column()]))
+        if (not self.data_array is None and len(self.data_array) > 0):
+            if int_role == Qt.ItemDataRole.BackgroundRole:
+                address = self.current_address + QModelIndex.row() * self.column_count + QModelIndex.column()
+                if SysUtils.modulo_address(address, GDB_Engine.inferior_arch) in self.breakpoint_list:
+                    return QVariant(QColor.red)
+            else:
+                return QVariant(SysUtils.aob_to_str(self.data_array[QModelIndex.row() * self.column_count + QModelIndex.column()]))
+        return QVariant()

--- a/GUI/CustomAbstractTableModels/HexModel.py
+++ b/GUI/CustomAbstractTableModels/HexModel.py
@@ -36,13 +36,14 @@ class QHexModel(QAbstractTableModel):
         return self.column_count
 
     def data(self, QModelIndex, int_role=None):
-        if (not self.data_array is None and len(self.data_array) > 0):
+        if (not self.data_array is None and len(self.data_array) > 0 and QModelIndex.isValid()):
             if int_role == Qt.ItemDataRole.BackgroundRole:
                 address = self.current_address + QModelIndex.row() * self.column_count + QModelIndex.column()
                 if SysUtils.modulo_address(address, GDB_Engine.inferior_arch) in self.breakpoint_list:
                     return QVariant(QColor.red)
-            else:
-                return QVariant(SysUtils.aob_to_str(self.data_array[QModelIndex.row() * self.column_count + QModelIndex.column()]))
+            elif int_role == Qt.ItemDataRole.DisplayRole:
+                return QVariant(self.data_array[QModelIndex.row() * self.column_count + QModelIndex.column()])
+
         return QVariant()
 
     def refresh(self, int_address, offset, data_array=None, breakpoint_info=None):

--- a/GUI/CustomAbstractTableModels/HexModel.py
+++ b/GUI/CustomAbstractTableModels/HexModel.py
@@ -36,17 +36,14 @@ class QHexModel(QAbstractTableModel):
         return self.column_count
 
     def data(self, QModelIndex, int_role=None):
-        if not QModelIndex.isValid():
-            return QVariant()
-        if int_role == Qt.ItemDataRole.BackgroundRole:
-            address = self.current_address + QModelIndex.row() * self.column_count + QModelIndex.column()
-            if SysUtils.modulo_address(address, GDB_Engine.inferior_arch) in self.breakpoint_list:
-                return QVariant(QColor(Qt.red))
-        elif int_role != Qt.DisplayRole:
-            return QVariant()
-        if self.data_array is None:
-            return QVariant()
-        return QVariant(self.data_array[QModelIndex.row() * self.column_count + QModelIndex.column()])
+        if (not self.data_array is None and len(self.data_array) > 0):
+            if int_role == Qt.ItemDataRole.BackgroundRole:
+                address = self.current_address + QModelIndex.row() * self.column_count + QModelIndex.column()
+                if SysUtils.modulo_address(address, GDB_Engine.inferior_arch) in self.breakpoint_list:
+                    return QVariant(QColor.red)
+            else:
+                return QVariant(SysUtils.aob_to_str(self.data_array[QModelIndex.row() * self.column_count + QModelIndex.column()]))
+        return QVariant()
 
     def refresh(self, int_address, offset, data_array=None, breakpoint_info=None):
         int_address = SysUtils.modulo_address(int_address, GDB_Engine.inferior_arch)

--- a/GUI/CustomLabels/FlagRegisterLabel.py
+++ b/GUI/CustomLabels/FlagRegisterLabel.py
@@ -35,9 +35,11 @@ class QFlagRegisterLabel(QLabel):
         self.setText(new)
 
     def enterEvent(self, QEvent):
-        self.setCursor(QCursor(Qt.PointingHandCursor))
+        self.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
 
     def mouseDoubleClickEvent(self, QMouseEvent):
+        if GDB_Engine.currentpid == -1:
+            return
         registers = GDB_Engine.read_registers()
         current_flag = self.objectName().lower()
         label_text = "Enter the new value of flag " + self.objectName()

--- a/GUI/CustomLabels/RegisterLabel.py
+++ b/GUI/CustomLabels/RegisterLabel.py
@@ -36,9 +36,11 @@ class QRegisterLabel(QLabel):
         self.setText(new)
 
     def enterEvent(self, QEvent):
-        self.setCursor(QCursor(Qt.PointingHandCursor))
+        self.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
 
     def mouseDoubleClickEvent(self, QMouseEvent):
+        if GDB_Engine.currentpid == -1:
+            return
         registers = GDB_Engine.read_registers()
         current_register = self.objectName().lower()
         register_dialog = InputDialogForm(
@@ -48,6 +50,8 @@ class QRegisterLabel(QLabel):
             self.set_value(GDB_Engine.read_registers()[current_register])
 
     def contextMenuEvent(self, QContextMenuEvent):
+        if GDB_Engine.currentpid == -1:
+            return
         menu = QMenu()
         show_in_hex_view = menu.addAction("Show in HexView")
         show_in_disassembler = menu.addAction("Show in Disassembler")

--- a/GUI/CustomTableViews/HexView.py
+++ b/GUI/CustomTableViews/HexView.py
@@ -40,12 +40,12 @@ class QHexView(QTableView):
         _self_name=self.__class__.__name__
         size = self.columnWidth(0) * self.model().columnCount()
         if (_self_name == "QHexView"):
-            self.setMinimumWidth(size*1.875)
-            self.setMaximumWidth(size*1.875)
+            self.setMinimumWidth(int(size*1.875))
+            self.setMaximumWidth(int(size*1.875))
             self.resizeColumnsToContents()
         else:
-            self.setMinimumWidth(size)
-            self.setMaximumWidth(size)
+            self.setMinimumWidth(int(size))
+            self.setMaximumWidth(int(size))
 
     def get_selected_address(self):
         ci = self.currentIndex()

--- a/GUI/CustomTableViews/HexView.py
+++ b/GUI/CustomTableViews/HexView.py
@@ -16,7 +16,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from PyQt6.QtWidgets import QTableView, QAbstractItemView
 from PyQt6.QtCore import Qt
-
 from libpince import SysUtils, GDB_Engine
 
 
@@ -38,9 +37,15 @@ class QHexView(QTableView):
         QWheelEvent.ignore()
 
     def resize_to_contents(self):
+        _self_name=self.__class__.__name__
         size = self.columnWidth(0) * self.model().columnCount()
-        self.setMinimumWidth(size)
-        self.setMaximumWidth(size)
+        if (_self_name == "QHexView"):
+            self.setMinimumWidth(size*2)
+            self.setMaximumWidth(size*2)
+            self.resizeColumnsToContents()
+        else:
+            self.setMinimumWidth(size)
+            self.setMaximumWidth(size)
 
     def get_selected_address(self):
         ci = self.currentIndex()

--- a/GUI/CustomTableViews/HexView.py
+++ b/GUI/CustomTableViews/HexView.py
@@ -40,8 +40,8 @@ class QHexView(QTableView):
         _self_name=self.__class__.__name__
         size = self.columnWidth(0) * self.model().columnCount()
         if (_self_name == "QHexView"):
-            self.setMinimumWidth(size*2)
-            self.setMaximumWidth(size*2)
+            self.setMinimumWidth(size*1.875)
+            self.setMaximumWidth(size*1.875)
             self.resizeColumnsToContents()
         else:
             self.setMinimumWidth(size)

--- a/GUI/CustomValidators/HexValidator.py
+++ b/GUI/CustomValidators/HexValidator.py
@@ -10,7 +10,7 @@ class QHexValidator(QValidator):
         try:
             int_repr = int(p_str, 0)
         except ValueError:
-            return QValidator.Intermediate, p_str, p_int
+            return QValidator.State.Intermediate, p_str, p_int
         if int_repr > self.max_limit:
-            return QValidator.Invalid, p_str, p_int
-        return QValidator.Acceptable, p_str, p_int
+            return QValidator.State.Invalid, p_str, p_int
+        return QValidator.State.Acceptable, p_str, p_int

--- a/GUI/MemoryViewerWindow.py
+++ b/GUI/MemoryViewerWindow.py
@@ -11,6 +11,13 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 
 class Ui_MainWindow_MemoryView(object):
     def setupUi(self, MainWindow_MemoryView):
+        """
+            Setup flag(s) to be used by hexview and dissabemly scrolling, so
+            that while scrolling, new scroll requests are disabled.
+        """
+        self.bHexViewScrolling = False
+        self.bDisassemblyScrolling = False
+
         MainWindow_MemoryView.setObjectName("MainWindow_MemoryView")
         MainWindow_MemoryView.resize(800, 600)
         self.centralwidget = QtWidgets.QWidget(MainWindow_MemoryView)

--- a/PINCE.py
+++ b/PINCE.py
@@ -1927,7 +1927,7 @@ class LoadingDialogForm(QDialog, LoadingDialog):
         self.movie = QMovie(media_directory + "/LoadingDialog/ajax-loader.gif", QByteArray())
         self.label_Animated.setMovie(self.movie)
         self.movie.setScaledSize(QSize(25, 25))
-        self.movie.setCacheMode(QMovie.CacheAll)
+        self.movie.setCacheMode(QMovie.CacheMode.CacheAll)
         self.movie.setSpeed(100)
         self.movie.start()
 
@@ -4441,7 +4441,7 @@ class TraceInstructionsWaitWidgetForm(QWidget, TraceInstructionsWaitWidget):
         self.label_Animated.setMovie(self.movie)
         self.movie.setScaledSize(QSize(215, 100))
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
-        self.movie.setCacheMode(QMovie.CacheAll)
+        self.movie.setCacheMode(QMovie.CacheMode.CacheAll)
         self.movie.setSpeed(100)
         self.movie.start()
         self.pushButton_Cancel.clicked.connect(self.close)

--- a/PINCE.py
+++ b/PINCE.py
@@ -18,6 +18,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
+from typing import Final
+
 from PyQt6.QtGui import QIcon, QMovie, QPixmap, QCursor, QKeySequence, QColor, QTextCharFormat, QBrush, QTextCursor, \
     QKeyEvent, QRegularExpressionValidator, QShortcut, QColorConstants
 from PyQt6.QtWidgets import QApplication, QMainWindow, QTableWidgetItem, QMessageBox, QDialog, QWidget, \
@@ -285,7 +287,7 @@ def except_hook(exception_type, value, tb):
             elif exception_type == type_defs.InferiorRunningException:
                 error_dialog = InputDialogForm(item_list=[(
                     "Process is running" + "\nPress " + Hotkeys.break_hotkey.get_active_key() + " to stop process" +
-                    "\n\nGo to Settings->General to disable this dialog",)], buttons=[QDialogButtonBox.Ok])
+                    "\n\nGo to Settings->General to disable this dialog",)], buttons=[QDialogButtonBox.StandardButton.Ok])
                 error_dialog.exec()
     traceback.print_exception(exception_type, value, tb)
 
@@ -355,7 +357,16 @@ class CheckInferiorStatus(QThread):
 # could pass to scanmem which then would set the current matches
 # the mainwindow
 class MainForm(QMainWindow, MainWindow):
+
     def __init__(self):
+        """
+            Declare regular expressions for hexadecimal and decimal input
+            to be used in checkBox_Hex_stateChanged (or anywhere else that
+            they are needed).
+        """
+        self.qRegExp_hex: Final[QRegularExpression] = QRegularExpression("(0x)?[A-Fa-f0-9]*$")
+        self.qRegExp_dec: Final[QRegularExpression] = QRegularExpression("-?[0-9]*")
+
         super().__init__()
         self.setupUi(self)
         self.hotkey_to_shortcut = {}
@@ -403,7 +414,7 @@ class MainForm(QMainWindow, MainWindow):
             text = "Unable to initialize GDB\n" \
                    "You might want to reinstall GDB or use the system GDB\n" \
                    "To change the current GDB path, check Settings->Debug"
-            InputDialogForm(item_list=[(text, None)], buttons=[QDialogButtonBox.Ok]).exec()
+            InputDialogForm(item_list=[(text, None)], buttons=[QDialogButtonBox.StandardButton.Ok]).exec()
         else:
             self.apply_after_init()
         # this should be changed, only works if you use the current directory, fails if you for example install it to some place like bin
@@ -480,6 +491,9 @@ class MainForm(QMainWindow, MainWindow):
         self.pushButton_Console.setIcon(QIcon(QPixmap(icons_directory + "/application_xp_terminal.png")))
         self.pushButton_Wiki.setIcon(QIcon(QPixmap(icons_directory + "/book_open.png")))
         self.pushButton_About.setIcon(QIcon(QPixmap(icons_directory + "/information.png")))
+        self.QWidget_Toolbox.setEnabled(True)
+        self.pushButton_NextScan.setEnabled(False)
+        self.pushButton_UndoScan.setEnabled(False)
         self.auto_attach()
 
     def set_default_settings(self):
@@ -624,10 +638,12 @@ class MainForm(QMainWindow, MainWindow):
             dialog_text = "GDB is attached back to the process"
         if show_messagebox_on_toggle_attach:
             dialog = InputDialogForm(item_list=[(
-                dialog_text + "\n\nGo to Settings->General to disable this dialog",)], buttons=[QDialogButtonBox.Ok])
+                dialog_text + "\n\nGo to Settings->General to disable this dialog",)], buttons=[QDialogButtonBox.StandardButton.Ok])
             dialog.exec()
 
     def treeWidget_AddressTable_context_menu_event(self, event):
+        if self.treeWidget_AddressTable.topLevelItemCount() == 0:
+            return
         current_row = GuiUtils.get_current_item(self.treeWidget_AddressTable)
         menu = QMenu()
         edit_menu = menu.addMenu("Edit")
@@ -968,18 +984,20 @@ class MainForm(QMainWindow, MainWindow):
         console_widget.showMaximized()
 
     def checkBox_Hex_stateChanged(self, state):
-        if state == Qt.CheckState.Checked:
+        if Qt.CheckState(state) == Qt.CheckState.Checked:
             # allows only things that are hex, can also start with 0x
-            self.lineEdit_Scan.setValidator(QRegExpValidator(QRegExp("(0x)?[A-Fa-f0-9]*$"), parent=self.lineEdit_Scan))
-            self.lineEdit_Scan2.setValidator(
-                QRegExpValidator(QRegExp("(0x)?[A-Fa-f0-9]*$"), parent=self.lineEdit_Scan2))
+            self.lineEdit_Scan.setValidator(QRegularExpressionValidator(self.qRegExp_hex, parent=self.lineEdit_Scan))
+            self.lineEdit_Scan2.setValidator(QRegularExpressionValidator(self.qRegExp_hex, parent=self.lineEdit_Scan2))
         else:
             # sets it back to integers only
-            self.lineEdit_Scan.setValidator(QRegExpValidator(QRegExp("-?[0-9]*"), parent=self.lineEdit_Scan))
-            self.lineEdit_Scan2.setValidator(QRegExpValidator(QRegExp("-?[0-9]*"), parent=self.lineEdit_Scan2))
+            self.lineEdit_Scan.setValidator(QRegularExpressionValidator(self.qRegExp_dec, parent=self.lineEdit_Scan))
+            self.lineEdit_Scan2.setValidator(QRegularExpressionValidator(self.qRegExp_dec, parent=self.lineEdit_Scan2))
 
     # TODO add a damn keybind for this...
     def pushButton_NewFirstScan_clicked(self):
+        self.comboBox_ScanType_init()
+        if GDB_Engine.currentpid == -1:
+            return
         if self.scan_mode == type_defs.SCAN_MODE.ONGOING:
             self.scan_mode = type_defs.SCAN_MODE.NEW
             self.pushButton_NewFirstScan.setText("First Scan")
@@ -999,7 +1017,7 @@ class MainForm(QMainWindow, MainWindow):
             self.backend.send_command("reset")
             self.comboBox_ScanScope.setEnabled(False)
             self.pushButton_NextScan_clicked()  # makes code a little simpler to just implement everything in nextscan
-        self.comboBox_ScanType_init()
+
 
     def comboBox_ScanType_current_index_changed(self):
         hidden_types = [type_defs.SCAN_TYPE.INCREASED, type_defs.SCAN_TYPE.DECREASED, type_defs.SCAN_TYPE.CHANGED,
@@ -1086,6 +1104,8 @@ class MainForm(QMainWindow, MainWindow):
         return search_for
 
     def pushButton_NextScan_clicked(self):
+        if GDB_Engine.currentpid == -1:
+            return
         global ProgressRun
         search_for = self.validate_search(self.lineEdit_Scan.text(), self.lineEdit_Scan2.text())
 
@@ -1236,11 +1256,13 @@ class MainForm(QMainWindow, MainWindow):
 
         # enable scan GUI
         self.lineEdit_Scan.setPlaceholderText("Scan for")
-        # self.QWidget_Toolbox.setEnabled(True)
-        # self.pushButton_NextScan.setEnabled(False)
-        # self.pushButton_UndoScan.setEnabled(False)
+        self.QWidget_Toolbox.setEnabled(True)
+        self.pushButton_NextScan.setEnabled(False)
+        self.pushButton_UndoScan.setEnabled(False)
 
     def delete_address_table_contents(self):
+        if self.treeWidget_AddressTable.topLevelItemCount() == 0:
+            return
         confirm_dialog = InputDialogForm(item_list=[("This will clear the contents of address table\nProceed?",)])
         if confirm_dialog.exec():
             self.treeWidget_AddressTable.clear()
@@ -2265,7 +2287,7 @@ class ConsoleWidgetForm(QWidget, ConsoleWidget):
         self.completion_model = QStringListModel()
         self.completer = QCompleter()
         self.completer.setModel(self.completion_model)
-        self.completer.setCompletionMode(QCompleter.UnfilteredPopupCompletion)
+        self.completer.setCompletionMode(QCompleter.CompletionMode.UnfilteredPopupCompletion)
         self.completer.setMaxVisibleItems(8)
         self.lineEdit.setCompleter(self.completer)
         self.quit_commands = ("q", "quit", "-gdb-exit")
@@ -2621,25 +2643,35 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
         self.verticalScrollBar_HexView.mouseReleaseEvent = self.verticalScrollBar_HexView_mouse_release_event
 
     def show_trace_window(self):
+        if GDB_Engine.currentpid == -1:
+            return
         trace_instructions_window = TraceInstructionsWindowForm(prompt_dialog=False)
         trace_instructions_window.showMaximized()
 
     def step_instruction(self):
+        if GDB_Engine.currentpid == -1:
+            return
         if self.updating_memoryview:
             return
         GDB_Engine.step_instruction()
 
     def step_over_instruction(self):
+        if GDB_Engine.currentpid == -1:
+            return
         if self.updating_memoryview:
             return
         GDB_Engine.step_over_instruction()
 
     def execute_till_return(self):
+        if GDB_Engine.currentpid == -1:
+            return
         if self.updating_memoryview:
             return
         GDB_Engine.execute_till_return()
 
     def set_address(self):
+        if GDB_Engine.currentpid == -1:
+            return
         selected_row = GuiUtils.get_current_row(self.tableWidget_Disassemble)
         current_address_text = self.tableWidget_Disassemble.item(selected_row, DISAS_ADDR_COL).text()
         current_address = SysUtils.extract_address(current_address_text)
@@ -2647,6 +2679,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
         self.refresh_disassemble_view()
 
     def nop_instruction(self):
+        if GDB_Engine.currentpid == -1:
+            return
         selected_row = GuiUtils.get_current_row(self.tableWidget_Disassemble)
         current_address_text = self.tableWidget_Disassemble.item(selected_row, DISAS_ADDR_COL).text()
         current_address = SysUtils.extract_address(current_address_text)
@@ -2657,6 +2691,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
 
     @GDB_Engine.execute_with_temporary_interruption
     def toggle_breakpoint(self):
+        if GDB_Engine.currentpid == -1:
+            return
         selected_row = GuiUtils.get_current_row(self.tableWidget_Disassemble)
         current_address_text = self.tableWidget_Disassemble.item(selected_row, DISAS_ADDR_COL).text()
         current_address = SysUtils.extract_address(current_address_text)
@@ -2669,6 +2705,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
         self.refresh_disassemble_view()
 
     def toggle_watchpoint(self, address, watchpoint_type=type_defs.WATCHPOINT_TYPE.BOTH):
+        if GDB_Engine.currentpid == -1:
+            return
         if GDB_Engine.check_address_in_breakpoints(address):
             GDB_Engine.delete_breakpoint(hex(address))
         else:
@@ -2687,6 +2725,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
         self.refresh_hex_view()
 
     def label_HexView_Information_context_menu_event(self, event):
+        if GDB_Engine.currentpid == -1:
+            return
         def copy_to_clipboard():
             app.clipboard().setText(self.label_HexView_Information.text())
 
@@ -2704,6 +2744,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
             pass
 
     def widget_HexView_context_menu_event(self, event):
+        if GDB_Engine.currentpid == -1:
+            return
         selected_address = self.tableView_HexView_Hex.get_selected_address()
         menu = QMenu()
         edit = menu.addAction("Edit")
@@ -2746,11 +2788,15 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
             pass
 
     def exec_hex_view_edit_dialog(self):
+        if GDB_Engine.currentpid == -1:
+            return
         selected_address = self.tableView_HexView_Hex.get_selected_address()
         HexEditDialogForm(hex(selected_address)).exec()
         self.refresh_hex_view()
 
     def exec_hex_view_go_to_dialog(self):
+        if GDB_Engine.currentpid == -1:
+            return
         current_address = hex(self.tableView_HexView_Hex.get_selected_address())
         go_to_dialog = InputDialogForm(item_list=[("Enter the expression", current_address)])
         if go_to_dialog.exec():
@@ -2762,6 +2808,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
             self.hex_dump_address(int(dest_address, 16))
 
     def exec_hex_view_add_address_dialog(self):
+        if GDB_Engine.currentpid == -1:
+            return
         selected_address = self.tableView_HexView_Hex.get_selected_address()
         manual_address_dialog = ManualAddressDialogForm(address=hex(selected_address),
                                                         index=type_defs.VALUE_INDEX.INDEX_AOB)
@@ -2806,6 +2854,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
             self.tableWidget_Disassemble_scroll("next", instructions_per_scroll)
 
     def on_hex_view_current_changed(self, QModelIndex_current):
+        if GDB_Engine.currentpid == -1:
+            return
         self.tableWidget_HexView_Address.setSelectionMode(QAbstractItemView.SingleSelection)
         self.hex_view_last_selected_address_int = self.tableView_HexView_Hex.get_selected_address()
         self.tableView_HexView_Ascii.selectionModel().setCurrentIndex(QModelIndex_current,
@@ -2814,6 +2864,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
         self.tableWidget_HexView_Address.setSelectionMode(QAbstractItemView.NoSelection)
 
     def on_ascii_view_current_changed(self, QModelIndex_current):
+        if GDB_Engine.currentpid == -1:
+            return
         self.tableWidget_HexView_Address.setSelectionMode(QAbstractItemView.SingleSelection)
         self.tableView_HexView_Hex.selectionModel().setCurrentIndex(QModelIndex_current,
                                                                     QItemSelectionModel.ClearAndSelect)
@@ -2824,6 +2876,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
     # TODO: Move this function to that class if that happens
     # TODO: Also consider moving shared fields of HexView and HexModel to that class(such as HexModel.current_address)
     def hex_dump_address(self, int_address, offset=HEX_VIEW_ROW_COUNT * HEX_VIEW_COL_COUNT):
+        if GDB_Engine.currentpid == -1:
+            return
         int_address = SysUtils.modulo_address(int_address, GDB_Engine.inferior_arch)
         if not (self.hex_view_current_region.start <= int_address < self.hex_view_current_region.end):
             information = SysUtils.get_region_info(GDB_Engine.currentpid, int_address)
@@ -2873,6 +2927,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
             self.tableView_HexView_Ascii.clearSelection()
 
     def refresh_hex_view(self):
+        if GDB_Engine.currentpid == -1:
+            return
         if self.tableWidget_HexView_Address.rowCount() == 0:
             entry_point = GDB_Engine.find_entry_point()
             if not entry_point:
@@ -2887,6 +2943,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
     # offset can also be an address as hex str
     # returns True if the given expression is disassembled correctly, False if not
     def disassemble_expression(self, expression, offset="+200", append_to_travel_history=False):
+        if GDB_Engine.currentpid == -1:
+            return
         disas_data = GDB_Engine.disassemble(expression, offset)
         if not disas_data:
             QMessageBox.information(app.focusWidget(), "Error", "Cannot access memory at expression " + expression)
@@ -3011,10 +3069,14 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
         return True
 
     def refresh_disassemble_view(self):
+        if GDB_Engine.currentpid == -1:
+            return
         self.disassemble_expression(self.disassemble_currently_displayed_address)
 
     # Set colour of a row if a specific address is encountered(e.g $pc, a bookmarked address etc.)
     def handle_colours(self, row_colour):
+        if GDB_Engine.currentpid == -1:
+            return
         for row in row_colour:
             current_row = row_colour[row]
             if PC_COLOUR in current_row:
@@ -3041,6 +3103,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
 
     # color parameter should be Qt.colour
     def set_row_colour(self, row, colour):
+        if GDB_Engine.currentpid == -1:
+            return
         for col in range(self.tableWidget_Disassemble.columnCount()):
             self.tableWidget_Disassemble.item(row, col).setData(Qt.ItemDataRole.BackgroundRole, QColor(colour))
 
@@ -3085,6 +3149,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
         self.setWindowTitle("Memory Viewer - Running")
 
     def add_breakpoint_condition(self, int_address):
+        if GDB_Engine.currentpid == -1:
+            return
         condition_text = "Enter the expression for condition, for instance:\n\n" + \
                          "$eax==0x523\n" + \
                          "$rax>0 && ($rbp<0 || $rsp==0)\n" + \
@@ -3103,6 +3169,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
                                         hex(int_address) + "\nCheck terminal for details")
 
     def update_registers(self):
+        if GDB_Engine.currentpid == -1:
+            return
         registers = GDB_Engine.read_registers()
         if GDB_Engine.inferior_arch == type_defs.INFERIOR_ARCH.ARCH_64:
             self.stackedWidget.setCurrentWidget(self.registers_64)
@@ -3151,6 +3219,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
         self.FS.set_value(registers["fs"])
 
     def update_stacktrace(self):
+        if GDB_Engine.currentpid == -1:
+            return
         stack_trace_info = GDB_Engine.get_stacktrace_info()
         self.tableWidget_StackTrace.setRowCount(0)
         self.tableWidget_StackTrace.setRowCount(len(stack_trace_info))
@@ -3159,6 +3229,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
             self.tableWidget_StackTrace.setItem(row, STACKTRACE_FRAME_ADDRESS_COL, QTableWidgetItem(item[1]))
 
     def set_stack_widget(self, stack_widget):
+        if GDB_Engine.currentpid == -1:
+            return
         self.stackedWidget_StackScreens.setCurrentWidget(stack_widget)
         if stack_widget == self.Stack:
             self.update_stack()
@@ -3166,6 +3238,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
             self.update_stacktrace()
 
     def tableWidget_StackTrace_context_menu_event(self, event):
+        if GDB_Engine.currentpid == -1:
+            return
         def copy_to_clipboard(row, column):
             app.clipboard().setText(self.tableWidget_StackTrace.item(row, column).text())
 
@@ -3195,6 +3269,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
             pass
 
     def update_stack(self):
+        if GDB_Engine.currentpid == -1:
+            return
         stack_info = GDB_Engine.get_stack_info()
         self.tableWidget_Stack.setRowCount(0)
         self.tableWidget_Stack.setRowCount(len(stack_info))
@@ -3206,6 +3282,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
         self.tableWidget_Stack.resizeColumnToContents(STACK_VALUE_COL)
 
     def tableWidget_Stack_key_press_event(self, event):
+        if GDB_Engine.currentpid == -1:
+            return
         selected_row = GuiUtils.get_current_row(self.tableWidget_Stack)
         current_address_text = self.tableWidget_Stack.item(selected_row, STACK_VALUE_COL).text()
         current_address = SysUtils.extract_address(current_address_text)
@@ -3223,6 +3301,9 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
         self.tableWidget_Stack.keyPressEvent_original(event)
 
     def tableWidget_Stack_context_menu_event(self, event):
+        if GDB_Engine.currentpid == -1:
+            return
+
         def copy_to_clipboard(row, column):
             app.clipboard().setText(self.tableWidget_Stack.item(row, column).text())
 
@@ -3261,6 +3342,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
             pass
 
     def tableWidget_Stack_double_click(self, index):
+        if GDB_Engine.currentpid == -1:
+            return
         selected_row = GuiUtils.get_current_row(self.tableWidget_Stack)
         if index.column() == STACK_POINTER_ADDRESS_COL:
             current_address_text = self.tableWidget_Stack.item(selected_row, STACK_POINTER_ADDRESS_COL).text()
@@ -3276,6 +3359,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
                 self.disassemble_expression(current_address, append_to_travel_history=True)
 
     def tableWidget_StackTrace_double_click(self, index):
+        if GDB_Engine.currentpid == -1:
+            return
         selected_row = GuiUtils.get_current_row(self.tableWidget_StackTrace)
         if index.column() == STACKTRACE_RETURN_ADDRESS_COL:
             current_address_text = self.tableWidget_StackTrace.item(selected_row, STACKTRACE_RETURN_ADDRESS_COL).text()
@@ -3287,6 +3372,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
             self.hex_dump_address(int(current_address, 16))
 
     def tableWidget_StackTrace_key_press_event(self, event):
+        if GDB_Engine.currentpid == -1:
+            return
         actions = type_defs.KeyboardModifiersTupleDict([
             (QKeyCombination(Qt.KeyboardModifier.NoModifier, Qt.Key.Key_R), self.update_stacktrace)
         ])
@@ -3297,6 +3384,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
         self.tableWidget_StackTrace.keyPressEvent_original(event)
 
     def widget_Disassemble_wheel_event(self, event):
+        if GDB_Engine.currentpid == -1:
+            return
         steps = event.angleDelta()
         if steps.y() > 0:
             self.tableWidget_Disassemble_scroll("previous", instructions_per_scroll)
@@ -3304,6 +3393,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
             self.tableWidget_Disassemble_scroll("next", instructions_per_scroll)
 
     def disassemble_check_viewport(self, where, instruction_count):
+        if GDB_Engine.currentpid == -1:
+            return
         current_row = GuiUtils.get_current_row(self.tableWidget_Disassemble)
         current_row_height = self.tableWidget_Disassemble.rowViewportPosition(current_row)
         row_height = self.tableWidget_Disassemble.verticalHeader().defaultSectionSize()
@@ -3324,11 +3415,15 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
             self.tableWidget_Disassemble_scroll(where, instruction_count)
 
     def tableWidget_Disassemble_scroll(self, where, instruction_count):
+        if GDB_Engine.currentpid == -1:
+            return
         current_address = self.disassemble_currently_displayed_address
         new_address = GDB_Engine.find_address_of_closest_instruction(current_address, where, instruction_count)
         self.disassemble_expression(new_address)
 
     def widget_HexView_wheel_event(self, event):
+        if GDB_Engine.currentpid == -1:
+            return
         steps = event.angleDelta()
         current_address = self.hex_model.current_address
         if steps.y() > 0:
@@ -3338,6 +3433,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
         self.hex_dump_address(next_address)
 
     def widget_HexView_key_press_event(self, event):
+        if GDB_Engine.currentpid == -1:
+            return
         selected_address = self.tableView_HexView_Hex.get_selected_address()
 
         actions = type_defs.KeyboardModifiersTupleDict([
@@ -3354,6 +3451,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
         self.tableView_HexView_Hex.keyPressEvent_original(event)
 
     def tableWidget_Disassemble_key_press_event(self, event):
+        if GDB_Engine.currentpid == -1:
+            return
         selected_row = GuiUtils.get_current_row(self.tableWidget_Disassemble)
         current_address_text = self.tableWidget_Disassemble.item(selected_row, DISAS_ADDR_COL).text()
         current_address = SysUtils.extract_address(current_address_text)
@@ -3378,6 +3477,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
         self.tableWidget_Disassemble.keyPressEvent_original(event)
 
     def tableWidget_Disassemble_item_double_clicked(self, index):
+        if GDB_Engine.currentpid == -1:
+            return
         if index.column() == DISAS_COMMENT_COL:
             selected_row = GuiUtils.get_current_row(self.tableWidget_Disassemble)
             current_address_text = self.tableWidget_Disassemble.item(selected_row, DISAS_ADDR_COL).text()
@@ -3388,6 +3489,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
                 self.bookmark_address(current_address)
 
     def tableWidget_Disassemble_item_selection_changed(self):
+        if GDB_Engine.currentpid == -1:
+            return
         try:
             selected_row = GuiUtils.get_current_row(self.tableWidget_Disassemble)
             selected_address_text = self.tableWidget_Disassemble.item(selected_row, DISAS_ADDR_COL).text()
@@ -3398,18 +3501,25 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
     # Search the item in given row for location changing instructions
     # Go to the address pointed by that instruction if it contains any
     def follow_instruction(self, selected_row):
+        if GDB_Engine.currentpid == -1:
+            return
         address = SysUtils.instruction_follow_address(
             self.tableWidget_Disassemble.item(selected_row, DISAS_OPCODES_COL).text())
         if address:
             self.disassemble_expression(address, append_to_travel_history=True)
 
     def disassemble_go_back(self):
+        if GDB_Engine.currentpid == -1:
+            return
         if self.tableWidget_Disassemble.travel_history:
             last_location = self.tableWidget_Disassemble.travel_history[-1]
             self.disassemble_expression(last_location)
             self.tableWidget_Disassemble.travel_history.pop()
 
     def tableWidget_Disassemble_context_menu_event(self, event):
+        if GDB_Engine.currentpid == -1:
+            return
+
         def copy_to_clipboard(row, column):
             app.clipboard().setText(self.tableWidget_Disassemble.item(row, column).text())
 
@@ -3503,6 +3613,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
             self.disassemble_expression(SysUtils.extract_address(action.text()), append_to_travel_history=True)
 
     def dissect_current_region(self):
+        if GDB_Engine.currentpid == -1:
+            return
         selected_row = GuiUtils.get_current_row(self.tableWidget_Disassemble)
         current_address_text = self.tableWidget_Disassemble.item(selected_row, DISAS_ADDR_COL).text()
         current_address = SysUtils.extract_address(current_address_text)
@@ -3512,6 +3624,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
         self.refresh_disassemble_view()
 
     def exec_examine_referrers_widget(self, current_address_text):
+        if GDB_Engine.currentpid == -1:
+            return
         if not GuiUtils.contains_reference_mark(current_address_text):
             return
         current_address = SysUtils.extract_address(current_address_text)
@@ -3520,6 +3634,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
         examine_referrers_widget.show()
 
     def exec_trace_instructions_dialog(self):
+        if GDB_Engine.currentpid == -1:
+            return
         selected_row = GuiUtils.get_current_row(self.tableWidget_Disassemble)
         current_address_text = self.tableWidget_Disassemble.item(selected_row, DISAS_ADDR_COL).text()
         current_address = SysUtils.extract_address(current_address_text)
@@ -3527,6 +3643,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
         trace_instructions_window.showMaximized()
 
     def exec_track_breakpoint_dialog(self):
+        if GDB_Engine.currentpid == -1:
+            return
         selected_row = GuiUtils.get_current_row(self.tableWidget_Disassemble)
         current_address_text = self.tableWidget_Disassemble.item(selected_row, DISAS_ADDR_COL).text()
         current_address = SysUtils.extract_address(current_address_text)
@@ -3535,6 +3653,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
         track_breakpoint_widget.show()
 
     def exec_disassemble_go_to_dialog(self):
+        if GDB_Engine.currentpid == -1:
+            return
         selected_row = GuiUtils.get_current_row(self.tableWidget_Disassemble)
         current_address_text = self.tableWidget_Disassemble.item(selected_row, DISAS_ADDR_COL).text()
         current_address = SysUtils.extract_address(current_address_text)
@@ -3545,6 +3665,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
             self.disassemble_expression(traveled_exp, append_to_travel_history=True)
 
     def bookmark_address(self, int_address):
+        if GDB_Engine.currentpid == -1:
+            return
         if int_address in self.tableWidget_Disassemble.bookmarks:
             QMessageBox.information(app.focusWidget(), "Error", "This address has already been bookmarked")
             return
@@ -3557,6 +3679,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
         self.refresh_disassemble_view()
 
     def change_bookmark_comment(self, int_address):
+        if GDB_Engine.currentpid == -1:
+            return
         current_comment = self.tableWidget_Disassemble.bookmarks[int_address]
         comment_dialog = InputDialogForm(item_list=[("Enter the comment for bookmarked address", current_comment)])
         if comment_dialog.exec():
@@ -3567,49 +3691,71 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
         self.refresh_disassemble_view()
 
     def delete_bookmark(self, int_address):
+        if GDB_Engine.currentpid == -1:
+            return
         if int_address in self.tableWidget_Disassemble.bookmarks:
             del self.tableWidget_Disassemble.bookmarks[int_address]
             self.refresh_disassemble_view()
 
     def actionBookmarks_triggered(self):
+        if GDB_Engine.currentpid == -1:
+            return
         bookmark_widget = BookmarkWidgetForm(self)
         bookmark_widget.show()
         bookmark_widget.activateWindow()
 
     def actionStackTrace_Info_triggered(self):
+        if GDB_Engine.currentpid == -1:
+            return
         self.stacktrace_info_widget = StackTraceInfoWidgetForm()
         self.stacktrace_info_widget.show()
 
     def actionBreakpoints_triggered(self):
+        if GDB_Engine.currentpid == -1:
+            return
         breakpoint_widget = BreakpointInfoWidgetForm(self)
         breakpoint_widget.show()
         breakpoint_widget.activateWindow()
 
     def actionFunctions_triggered(self):
+        if GDB_Engine.currentpid == -1:
+            return
         functions_info_widget = FunctionsInfoWidgetForm(self)
         functions_info_widget.show()
 
     def actionGDB_Log_File_triggered(self):
+        if GDB_Engine.currentpid == -1:
+            return
         log_file_widget = LogFileWidgetForm()
         log_file_widget.showMaximized()
 
     def actionMemory_Regions_triggered(self):
+        if GDB_Engine.currentpid == -1:
+            return
         memory_regions_widget = MemoryRegionsWidgetForm(self)
         memory_regions_widget.show()
 
     def actionRestore_Instructions_triggered(self):
+        if GDB_Engine.currentpid == -1:
+            return
         restore_instructions_widget = RestoreInstructionsWidgetForm(self)
         restore_instructions_widget.show()
 
     def actionReferenced_Strings_triggered(self):
+        if GDB_Engine.currentpid == -1:
+            return
         ref_str_widget = ReferencedStringsWidgetForm(self)
         ref_str_widget.show()
 
     def actionReferenced_Calls_triggered(self):
+        if GDB_Engine.currentpid == -1:
+            return
         ref_call_widget = ReferencedCallsWidgetForm(self)
         ref_call_widget.show()
 
     def actionInject_so_file_triggered(self):
+        if GDB_Engine.currentpid == -1:
+            return
         file_path = QFileDialog.getOpenFileName(self, "Select the .so file", "", "Shared object library (*.so)")[0]
         if file_path:
             if GDB_Engine.inject_with_dlopen_call(file_path):
@@ -3618,6 +3764,8 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
                 QMessageBox.information(self, "Error", "Failed to inject the .so file")
 
     def actionCall_Function_triggered(self):
+        if GDB_Engine.currentpid == -1:
+            return
         label_text = "Enter the expression for the function that'll be called from the inferior" \
                      "\nYou can view functions list from View->Functions" \
                      "\n\nFor instance:" \
@@ -3636,21 +3784,29 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
                 QMessageBox.information(self, "Failed", "Failed to call the expression " + call_dialog.get_values())
 
     def actionSearch_Opcode_triggered(self):
+        if GDB_Engine.currentpid == -1:
+            return
         start_address = int(self.disassemble_currently_displayed_address, 16)
         end_address = start_address + 0x30000
         search_opcode_widget = SearchOpcodeWidgetForm(hex(start_address), hex(end_address), self)
         search_opcode_widget.show()
 
     def actionDissect_Code_triggered(self):
+        if GDB_Engine.currentpid == -1:
+            return
         self.dissect_code_dialog = DissectCodeDialogForm()
         self.dissect_code_dialog.exec()
         self.refresh_disassemble_view()
 
     def actionlibpince_triggered(self):
+        if GDB_Engine.currentpid == -1:
+            return
         libpince_widget = LibpinceReferenceWidgetForm(is_window=True)
         libpince_widget.showMaximized()
 
     def pushButton_ShowFloatRegisters_clicked(self):
+        if GDB_Engine.currentpid == -1:
+            return
         self.float_registers_widget = FloatRegisterWidgetForm()
         self.float_registers_widget.show()
         GuiUtils.center_to_window(self.float_registers_widget, self.widget_Registers)
@@ -4528,7 +4684,7 @@ class FunctionsInfoWidgetForm(QWidget, FunctionsInfoWidget):
                "\n@plt means this function is a subroutine for the original one" \
                "\nThere can be more than one of the same function" \
                "\nIt means that the function is overloaded"
-        InputDialogForm(item_list=[(text, None, Qt.AlignmentFlag.AlignLeft)], buttons=[QDialogButtonBox.Ok]).exec()
+        InputDialogForm(item_list=[(text, None, Qt.AlignmentFlag.AlignLeft)], buttons=[QDialogButtonBox.StandardButton.Ok]).exec()
 
     def closeEvent(self, QCloseEvent):
         global instances
@@ -4976,7 +5132,7 @@ class SearchOpcodeWidgetForm(QWidget, SearchOpcodeWidget):
                "\n'[re]cx' searches for both 'rcx' and 'ecx'" \
                "\nUse the char '\\' to escape special chars such as '['" \
                "\n'\[rsp\]' searches for opcodes that contain '[rsp]'"
-        InputDialogForm(item_list=[(text, None, Qt.AlignmentFlag.AlignLeft)], buttons=[QDialogButtonBox.Ok]).exec()
+        InputDialogForm(item_list=[(text, None, Qt.AlignmentFlag.AlignLeft)], buttons=[QDialogButtonBox.StandardButton.Ok]).exec()
 
     def tableWidget_Opcodes_item_double_clicked(self, index):
         row = index.row()
@@ -5276,10 +5432,10 @@ class ReferencedStringsWidgetForm(QWidget, ReferencedStringsWidget):
         for row, item in enumerate(item_list):
             self.tableWidget_References.setItem(row, REF_STR_ADDR_COL, QTableWidgetItem(self.pad_hex(item[0])))
             table_widget_item = QTableWidgetItem()
-            table_widget_item.setData(Qt.EditRole, item[1])
+            table_widget_item.setData(Qt.ItemDataRole.EditRole, item[1])
             self.tableWidget_References.setItem(row, REF_STR_COUNT_COL, table_widget_item)
             table_widget_item = QTableWidgetItem()
-            table_widget_item.setData(Qt.EditRole, item[2])
+            table_widget_item.setData(Qt.ItemDataRole.EditRole, item[2])
             self.tableWidget_References.setItem(row, REF_STR_VAL_COL, table_widget_item)
         self.tableWidget_References.setSortingEnabled(True)
 
@@ -5409,7 +5565,7 @@ class ReferencedCallsWidgetForm(QWidget, ReferencedCallsWidget):
         for row, item in enumerate(item_list):
             self.tableWidget_References.setItem(row, REF_CALL_ADDR_COL, QTableWidgetItem(self.pad_hex(item[0])))
             table_widget_item = QTableWidgetItem()
-            table_widget_item.setData(Qt.EditRole, item[1])
+            table_widget_item.setData(Qt.ItemDataRole.EditRole, item[1])
             self.tableWidget_References.setItem(row, REF_CALL_COUNT_COL, table_widget_item)
         self.tableWidget_References.setSortingEnabled(True)
 

--- a/PINCE.py
+++ b/PINCE.py
@@ -2382,7 +2382,7 @@ class ConsoleWidgetForm(QWidget, ConsoleWidget):
 
     def scroll_to_bottom(self):
         cursor = self.textBrowser.textCursor()
-        cursor.movePosition(QTextCursor.End)
+        cursor.movePosition(QTextCursor.MoveOperation.End)
         self.textBrowser.setTextCursor(cursor)
         self.textBrowser.ensureCursorVisible()
 
@@ -4959,7 +4959,7 @@ class LibpinceReferenceWidgetForm(QWidget, LibpinceReferenceWidget):
             return
         cursor = self.textBrowser_TypeDefs.textCursor()
         cursor.clearSelection()
-        cursor.movePosition(QTextCursor.Start)
+        cursor.movePosition(QTextCursor.MoveOperation.Start)
         self.textBrowser_TypeDefs.setTextCursor(cursor)
         if self.current_found == self.found_count:
             self.current_found = 1
@@ -4975,7 +4975,7 @@ class LibpinceReferenceWidgetForm(QWidget, LibpinceReferenceWidget):
             return
         cursor = self.textBrowser_TypeDefs.textCursor()
         cursor.clearSelection()
-        cursor.movePosition(QTextCursor.Start)
+        cursor.movePosition(QTextCursor.MoveOperation.Start)
         self.textBrowser_TypeDefs.setTextCursor(cursor)
         if self.current_found == 1:
             self.current_found = self.found_count
@@ -4991,7 +4991,7 @@ class LibpinceReferenceWidgetForm(QWidget, LibpinceReferenceWidget):
         self.textBrowser_TypeDefs.setTextBackgroundColor(QColor("white"))
         cursor = self.textBrowser_TypeDefs.textCursor()
         cursor.clearSelection()
-        cursor.movePosition(QTextCursor.Start)
+        cursor.movePosition(QTextCursor.MoveOperation.Start)
         self.textBrowser_TypeDefs.setTextCursor(cursor)
 
         highlight_format = QTextCharFormat()
@@ -5010,7 +5010,7 @@ class LibpinceReferenceWidgetForm(QWidget, LibpinceReferenceWidget):
             return
         cursor = self.textBrowser_TypeDefs.textCursor()
         cursor.clearSelection()
-        cursor.movePosition(QTextCursor.Start)
+        cursor.movePosition(QTextCursor.MoveOperation.Start)
         self.textBrowser_TypeDefs.setTextCursor(cursor)
         self.textBrowser_TypeDefs.find(pattern)
         self.current_found = 1
@@ -5081,7 +5081,7 @@ class LogFileWidgetForm(QWidget, LogFileWidget):
 
             # Scrolling to bottom
             cursor = self.textBrowser_LogContent.textCursor()
-            cursor.movePosition(QTextCursor.End)
+            cursor.movePosition(QTextCursor.MoveOperation.End)
             self.textBrowser_LogContent.setTextCursor(cursor)
             self.textBrowser_LogContent.ensureCursorVisible()
         log_file.close()
@@ -5742,7 +5742,7 @@ class ExamineReferrersWidgetForm(QWidget, ExamineReferrersWidget):
         for item in disas_data:
             self.textBrowser_DisasInfo.append(item[0] + item[2])
         cursor = self.textBrowser_DisasInfo.textCursor()
-        cursor.movePosition(QTextCursor.Start)
+        cursor.movePosition(QTextCursor.MoveOperation.Start)
         self.textBrowser_DisasInfo.setTextCursor(cursor)
         self.textBrowser_DisasInfo.ensureCursorVisible()
 

--- a/PINCE.py
+++ b/PINCE.py
@@ -1910,8 +1910,8 @@ class LoadingDialogForm(QDialog, LoadingDialog):
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.setupUi(self)
-        self.setWindowFlags(self.windowFlags() | Qt.FramelessWindowHint)
-        self.setAttribute(Qt.WA_TranslucentBackground)
+        self.setWindowFlags(self.windowFlags() | Qt.WindowType.FramelessWindowHint)
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
         if parent:
             GuiUtils.center_to_parent(self)
         self.keyPressEvent = QEvent.ignore
@@ -4432,7 +4432,7 @@ class TraceInstructionsWaitWidgetForm(QWidget, TraceInstructionsWaitWidget):
     def __init__(self, address, breakpoint, parent=None):
         super().__init__(parent=parent)
         self.setupUi(self)
-        self.setWindowFlags(self.windowFlags() | Qt.Window | Qt.FramelessWindowHint)
+        self.setWindowFlags(self.windowFlags() | Qt.WindowType.Window | Qt.WindowType.FramelessWindowHint)
         GuiUtils.center(self)
         self.address = address
         self.breakpoint = breakpoint
@@ -4440,7 +4440,7 @@ class TraceInstructionsWaitWidgetForm(QWidget, TraceInstructionsWaitWidget):
         self.movie = QMovie(media_directory + "/TraceInstructionsWaitWidget/ajax-loader.gif", QByteArray())
         self.label_Animated.setMovie(self.movie)
         self.movie.setScaledSize(QSize(215, 100))
-        self.setAttribute(Qt.WA_TranslucentBackground)
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
         self.movie.setCacheMode(QMovie.CacheAll)
         self.movie.setSpeed(100)
         self.movie.start()
@@ -4951,7 +4951,7 @@ class LibpinceReferenceWidgetForm(QWidget, LibpinceReferenceWidget):
             self.tableWidget_ResourceTable.setItem(row, LIBPINCE_REFERENCE_ITEM_COL, table_widget_item)
             self.tableWidget_ResourceTable.setItem(row, LIBPINCE_REFERENCE_VALUE_COL, table_widget_item_value)
         self.tableWidget_ResourceTable.setSortingEnabled(True)
-        self.tableWidget_ResourceTable.sortByColumn(LIBPINCE_REFERENCE_ITEM_COL, Qt.AscendingOrder)
+        self.tableWidget_ResourceTable.sortByColumn(LIBPINCE_REFERENCE_ITEM_COL, Qt.SortOrder.AscendingOrder)
         GuiUtils.resize_to_contents(self.tableWidget_ResourceTable)
 
     def pushButton_TextDown_clicked(self):
@@ -5413,7 +5413,7 @@ class ReferencedStringsWidgetForm(QWidget, ReferencedStringsWidget):
                 dissect_code_dialog.scan_finished_signal.connect(dissect_code_dialog.accept)
                 dissect_code_dialog.exec()
         self.refresh_table()
-        self.tableWidget_References.sortByColumn(REF_STR_ADDR_COL, Qt.AscendingOrder)
+        self.tableWidget_References.sortByColumn(REF_STR_ADDR_COL, Qt.SortOrder.AscendingOrder)
         self.tableWidget_References.selectionModel().currentChanged.connect(self.tableWidget_References_current_changed)
         self.listWidget_Referrers.itemDoubleClicked.connect(self.listWidget_Referrers_item_double_clicked)
         self.tableWidget_References.itemDoubleClicked.connect(self.tableWidget_References_item_double_clicked)
@@ -5548,7 +5548,7 @@ class ReferencedCallsWidgetForm(QWidget, ReferencedCallsWidget):
                 dissect_code_dialog.scan_finished_signal.connect(dissect_code_dialog.accept)
                 dissect_code_dialog.exec()
         self.refresh_table()
-        self.tableWidget_References.sortByColumn(REF_CALL_ADDR_COL, Qt.AscendingOrder)
+        self.tableWidget_References.sortByColumn(REF_CALL_ADDR_COL, Qt.SortOrder.AscendingOrder)
         self.tableWidget_References.selectionModel().currentChanged.connect(self.tableWidget_References_current_changed)
         self.listWidget_Referrers.itemDoubleClicked.connect(self.listWidget_Referrers_item_double_clicked)
         self.tableWidget_References.itemDoubleClicked.connect(self.tableWidget_References_item_double_clicked)

--- a/PINCE.py
+++ b/PINCE.py
@@ -2856,21 +2856,21 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
     def on_hex_view_current_changed(self, QModelIndex_current):
         if GDB_Engine.currentpid == -1:
             return
-        self.tableWidget_HexView_Address.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.tableWidget_HexView_Address.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
         self.hex_view_last_selected_address_int = self.tableView_HexView_Hex.get_selected_address()
         self.tableView_HexView_Ascii.selectionModel().setCurrentIndex(QModelIndex_current,
-                                                                      QItemSelectionModel.ClearAndSelect)
+                                                                      QItemSelectionModel.SelectionFlag.ClearAndSelect)
         self.tableWidget_HexView_Address.selectRow(QModelIndex_current.row())
-        self.tableWidget_HexView_Address.setSelectionMode(QAbstractItemView.NoSelection)
+        self.tableWidget_HexView_Address.setSelectionMode(QAbstractItemView.SelectionMode.NoSelection)
 
     def on_ascii_view_current_changed(self, QModelIndex_current):
         if GDB_Engine.currentpid == -1:
             return
-        self.tableWidget_HexView_Address.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.tableWidget_HexView_Address.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
         self.tableView_HexView_Hex.selectionModel().setCurrentIndex(QModelIndex_current,
-                                                                    QItemSelectionModel.ClearAndSelect)
+                                                                    QItemSelectionModel.SelectionFlag.ClearAndSelect)
         self.tableWidget_HexView_Address.selectRow(QModelIndex_current.row())
-        self.tableWidget_HexView_Address.setSelectionMode(QAbstractItemView.NoSelection)
+        self.tableWidget_HexView_Address.setSelectionMode(QAbstractItemView.SelectionMode.NoSelection)
 
     # TODO: Consider merging HexView_Address, HexView_Hex and HexView_Ascii into one UI class
     # TODO: Move this function to that class if that happens
@@ -2915,12 +2915,12 @@ class MemoryViewWindowForm(QMainWindow, MemoryViewWindow):
                 row_index = int(index / HEX_VIEW_COL_COUNT)
                 model_index = QModelIndex(self.hex_model.index(row_index, index % HEX_VIEW_COL_COUNT))
                 self.tableView_HexView_Hex.selectionModel().setCurrentIndex(model_index,
-                                                                            QItemSelectionModel.ClearAndSelect)
+                                                                            QItemSelectionModel.SelectionFlag.ClearAndSelect)
                 self.tableView_HexView_Ascii.selectionModel().setCurrentIndex(model_index,
-                                                                              QItemSelectionModel.ClearAndSelect)
-                self.tableWidget_HexView_Address.setSelectionMode(QAbstractItemView.SingleSelection)
+                                                                              QItemSelectionModel.SelectionFlag.ClearAndSelect)
+                self.tableWidget_HexView_Address.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
                 self.tableWidget_HexView_Address.selectRow(row_index)
-                self.tableWidget_HexView_Address.setSelectionMode(QAbstractItemView.NoSelection)
+                self.tableWidget_HexView_Address.setSelectionMode(QAbstractItemView.SelectionMode.NoSelection)
                 break
         else:
             self.tableView_HexView_Hex.clearSelection()

--- a/TODO.md
+++ b/TODO.md
@@ -2,8 +2,7 @@
 ---
 **2022/11/24 -- Fix scrolling via the vertical scrollbar in memoryview**
 
-+ Currently using the vertical scrollbar to scroll the disassembled instructions
-in the memoryview results in endless scrolling.
++ Currently using the vertical scrollbar to scroll the disassembled instructions in the memoryview, and in hex view, results in endless movement of the scrollbar but no actual scrolling takes place.
 
 ---
 
@@ -15,6 +14,8 @@ in the memoryview results in endless scrolling.
 
 [fixed] + Additionally, the hex digits are not showing two digits per entry (eg 12 34, instead of 1 3)
 
-+ Ascii text-view has <?> for non-printable characters, this needs to be changed to .
+[fixed] + Ascii text-view has <?> for non-printable characters, this needs to be changed to .
+
++ Pressing PgUp/Dn, or arrow keys does not scroll the hex view (but the mouse wheel does)
 
 ---

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,9 @@
+
+===
+**Fix scrolling via the vertical scrollbar in memoryview**
+
+===
+Currently using the vertical scrollbar to scroll the disassembled instructions
+in the memoryview results in endless scrolling.
+
+===

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,8 @@
 
-===
+---
 **2022/11/24 -- Fix scrolling via the vertical scrollbar in memoryview**
 
-===
-Currently using the vertical scrollbar to scroll the disassembled instructions
++ Currently using the vertical scrollbar to scroll the disassembled instructions
 in the memoryview results in endless scrolling.
 
-===
+---

--- a/TODO.md
+++ b/TODO.md
@@ -6,3 +6,15 @@
 in the memoryview results in endless scrolling.
 
 ---
+
+---
+**2022/11/24 -- Hex and Ascii Models in Memory View Don't show the proper values**
+
++ Currently the Hex and Ascii Viewer are showing black squares, or <?>, it should
+  show the hex value (in the hex view) and the Ascii value (or a . for non-ascii).
+
++ Additionally, the hex digits are not showing two digits per entry (eg 12 34, instead of 1 3)
+
++ Ascii text-view has <?> for non-printable characters, this needs to be changed to .
+
+---

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 ---
 **2022/11/24 -- Fix scrolling via the vertical scrollbar in memoryview**
 
-+ Currently using the vertical scrollbar to scroll the disassembled instructions in the memoryview, and in hex view, results in endless movement of the scrollbar but no actual scrolling takes place.
+[fixed] + Currently using the vertical scrollbar to scroll the disassembled instructions in the memoryview, and in hex view, results in endless movement of the scrollbar but no actual scrolling takes place.
 
 ---
 
@@ -16,6 +16,6 @@
 
 [fixed] + Ascii text-view has <?> for non-printable characters, this needs to be changed to .
 
-+ Pressing PgUp/Dn, or arrow keys does not scroll the hex view (but the mouse wheel does)
+[fixed] + Pressing PgUp/Dn, or arrow keys does not scroll the hex view (but the mouse wheel does)
 
 ---

--- a/TODO.md
+++ b/TODO.md
@@ -10,10 +10,10 @@ in the memoryview results in endless scrolling.
 ---
 **2022/11/24 -- Hex and Ascii Models in Memory View Don't show the proper values**
 
-+ Currently the Hex and Ascii Viewer are showing black squares, or <?>, it should
+[fixed] + Currently the Hex and Ascii Viewer are showing black squares, or <?>, it should
   show the hex value (in the hex view) and the Ascii value (or a . for non-ascii).
 
-+ Additionally, the hex digits are not showing two digits per entry (eg 12 34, instead of 1 3)
+[fixed] + Additionally, the hex digits are not showing two digits per entry (eg 12 34, instead of 1 3)
 
 + Ascii text-view has <?> for non-printable characters, this needs to be changed to .
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 
 ===
-**Fix scrolling via the vertical scrollbar in memoryview**
+**2022/11/24 -- Fix scrolling via the vertical scrollbar in memoryview**
 
 ===
 Currently using the vertical scrollbar to scroll the disassembled instructions

--- a/libpince/GDB_Engine.py
+++ b/libpince/GDB_Engine.py
@@ -377,7 +377,7 @@ def ___internal_continue_inferior():
 
 #:tag:Debug
 def ___internal_interrupt_inferior(interrupt_reason=type_defs.STOP_REASON.DEBUG):
-    """Interrupt the inferior 
+    """Interrupt the inferior
     see notes on ___internal_continue_inferior
     Args:
         interrupt_reason (int): Just changes the global variable stop_reason. Can be a member of type_defs.STOP_REASON
@@ -429,6 +429,8 @@ def interrupt_inferior(interrupt_reason=type_defs.STOP_REASON.DEBUG):
     Args:
         interrupt_reason (int): Just changes the global variable stop_reason. Can be a member of type_defs.STOP_REASON
     """
+    if currentpid == -1:
+        return
     global stop_reason
     send_command("c", control=True)
     wait_for_stop()
@@ -438,6 +440,8 @@ def interrupt_inferior(interrupt_reason=type_defs.STOP_REASON.DEBUG):
 #:tag:Debug
 def continue_inferior():
     """Continue the inferior"""
+    if currentpid == -1:
+        return
     send_command("c")
 
 
@@ -696,6 +700,8 @@ def toggle_attach():
         int: The new state of the process as a member of type_defs.TOGGLE_ATTACH
         None: If detaching or attaching fails
     """
+    if currentpid == -1:
+        return
     if is_attached():
         if common_regexes.gdb_error.search(send_command("phase-out")):
             return

--- a/libpince/SysUtils.py
+++ b/libpince/SysUtils.py
@@ -680,10 +680,13 @@ def aob_to_str(list_of_bytes, encoding="ascii"):
     newByte=0
 
     for sByte in byteList:
-        byte=int(sByte,16)
-        newByte=f'{byte:x}'
-        if ( (byte < 32) or (byte > 126) ):
-            newByte=f'{46:x}' # replace non-printable chars with a period (.)
+        if sByte == "??":
+            newByte=f'{63:x}'
+        else:
+            byte=int(sByte,16)
+            newByte=f'{byte:x}'
+            if ( (byte < 32) or (byte > 126) ):
+                newByte=f'{46:x}' # replace non-printable chars with a period (.)
 
     hexBytes=bytes.fromhex(newByte)
     return hexBytes.decode(encoding, "surrogateescape")

--- a/libpince/SysUtils.py
+++ b/libpince/SysUtils.py
@@ -680,7 +680,8 @@ def aob_to_str(list_of_bytes, encoding="ascii"):
     newByte=0
 
     for sByte in byteList:
-        if sByte == "??":
+        # if sByte is is ?? or if it is not a string -- replace with a period
+        if (sByte == "??") or (not isinstance(sByte, str)):
             newByte=f'{63:x}'
         else:
             byte=int(sByte,16)

--- a/libpince/SysUtils.py
+++ b/libpince/SysUtils.py
@@ -1079,7 +1079,7 @@ def ignore_exceptions(func):
 
     def wrapper(*args, **kwargs):
         try:
-            func(*targs, **kwargs)
+            func(*args, **kwargs)
         except:
             #print(f' Args: {args}' )
             #print(f' Kwargs: {kwargs}' )

--- a/libpince/SysUtils.py
+++ b/libpince/SysUtils.py
@@ -675,21 +675,38 @@ def aob_to_str(list_of_bytes, encoding="ascii"):
     """
 
     ### make an actual list of bytes
-    byteList = []
-    byteList.append(list_of_bytes)
+    hexString = ""
+    byteList = list_of_bytes
+    if (isinstance(list_of_bytes, list)):
+        byteList = list_of_bytes
+    else:
+        byteList = []
+        byteList.append(list_of_bytes)
+
     newByte=0
 
     for sByte in byteList:
-        # if sByte is is ?? or if it is not a string -- replace with a period
-        if (sByte == "??") or (not isinstance(sByte, str)):
-            newByte=f'{63:x}'
+        if (sByte == "??"):
+            hexString += f'{63:02x}' # replace ?? with a single ?
         else:
-            byte=int(sByte,16)
-            newByte=f'{byte:x}'
-            if ( (byte < 32) or (byte > 126) ):
-                newByte=f'{46:x}' # replace non-printable chars with a period (.)
+            if (isinstance(sByte, int)):
+                byte=sByte
+            else:
+                byte=int(sByte,16)
+            """NOTE: replacing non-printable chars with a period will
+            have an adverse effect on the ability to edit hex/ASCII data
+            since the editor dialog will replace the hex bytes with 2e rather
+            than replacing only the edited bytes.
 
-    hexBytes=bytes.fromhex(newByte)
+            So for now, don't replace them -- but be aware that this clutters
+            the ascii text in the memory view and does not look 'neat'
+            """
+            #if ( (byte < 32) or (byte > 126) ):
+            #    hexString += f'{46:02x}' # replace non-printable chars with a period (.)
+            #else:
+            hexString += f'{byte:02x}'
+
+    hexBytes=bytes.fromhex(hexString)
     return hexBytes.decode(encoding, "surrogateescape")
 
 #:tag:ValueType
@@ -703,7 +720,7 @@ def str_to_aob(string, encoding="ascii"):
     Returns:
         str: AoB equivalent of the given string
     """
-    s = str(binascii.hexlify(string.encode(encoding, "surrogateescape")), "ascii")
+    s = str(binascii.hexlify(string.encode(encoding, "surrogateescape")), encoding)
     return " ".join(s[i:i + 2] for i in range(0, len(s), 2))
 
 

--- a/libpince/SysUtils.py
+++ b/libpince/SysUtils.py
@@ -1078,21 +1078,11 @@ def ignore_exceptions(func):
     """A decorator to ignore exceptions"""
 
     def wrapper(*args, **kwargs):
-        """
-            The arguments seems to be:
-            [0] object <pointer>
-            [1] boolean [true/false]
-
-            Strip last item (the boolean)
-            from the args,
-        """
-        targs = args[0:len(args)-1]
         try:
             func(*targs, **kwargs)
         except:
             #print(f' Args: {args}' )
             #print(f' Kwargs: {kwargs}' )
-            #print(f' targs: {targs}' )
             traceback.print_exc()
 
     return wrapper

--- a/libpince/SysUtils.py
+++ b/libpince/SysUtils.py
@@ -674,9 +674,19 @@ def aob_to_str(list_of_bytes, encoding="ascii"):
         str: str equivalent of array
     """
 
-    # 3f is ascii hex representation of char "?"
-    return bytes.fromhex("".join(list_of_bytes).replace("??", "3f")).decode(encoding, "surrogateescape")
+    ### make an actual list of bytes
+    byteList = []
+    byteList.append(list_of_bytes)
+    newByte=0
 
+    for sByte in byteList:
+        byte=int(sByte,16)
+        newByte=f'{byte:x}'
+        if ( (byte < 32) or (byte > 126) ):
+            newByte=f'{46:x}' # replace non-printable chars with a period (.)
+
+    hexBytes=bytes.fromhex(newByte)
+    return hexBytes.decode(encoding, "surrogateescape")
 
 #:tag:ValueType
 def str_to_aob(string, encoding="ascii"):

--- a/libpince/SysUtils.py
+++ b/libpince/SysUtils.py
@@ -1065,9 +1065,21 @@ def ignore_exceptions(func):
     """A decorator to ignore exceptions"""
 
     def wrapper(*args, **kwargs):
+        """
+            The arguments seems to be:
+            [0] object <pointer>
+            [1] boolean [true/false]
+
+            Strip last item (the boolean)
+            from the args,
+        """
+        targs = args[0:len(args)-1]
         try:
-            func(*args, **kwargs)
+            func(*targs, **kwargs)
         except:
+            #print(f' Args: {args}' )
+            #print(f' Kwargs: {kwargs}' )
+            #print(f' targs: {targs}' )
             traceback.print_exc()
 
     return wrapper

--- a/libpince/type_defs.py
+++ b/libpince/type_defs.py
@@ -510,11 +510,11 @@ class KeyboardModifiersTupleDict(collections.abc.Mapping):
     def __init__(self, OrderedDict_like_list):
         new_dict = {}
         for keycomb, value in OrderedDict_like_list:
-            new_dict[keycomb.toCombined()] = value
+            new_dict[keycomb] = value
         self._storage = new_dict
 
     def __getitem__(self, keycomb):
-        return self._storage[keycomb.toCombined()]
+        return self._storage[keycomb]
 
     def __iter__(self):
         return iter(self._storage)

--- a/libpince/type_defs.py
+++ b/libpince/type_defs.py
@@ -521,3 +521,4 @@ class KeyboardModifiersTupleDict(collections.abc.Mapping):
 
     def __len__(self):
         return len(self._storage)
+


### PR DESCRIPTION
This PR mainly fixes:

1. Traceback crashes due to attributes not being in the global Qt namespace (eg. enum values need to be prefixed with the name of the enum, Qt.NAME.MEMBER)
2. The Hex and ASCII view now correctly shows all 16 bytes (instead of 8) and  unprintable characters are replaced with periods.
3. Scrolling via scrollbars and page up/down now works -- Eg. The scroll event will now only happen once (as opposed to getting stuck and scrolling indefinitely).
4. Keypress events (QKeyCombinations) now work properly and the dictionary can now return the methods to execute.

NOTE: This is also an update to PR #142

I will have more to add at a later time -- which is why I created this as a draft.